### PR TITLE
Fix get terminalWidth in non-interactive mode

### DIFF
--- a/yargs.js
+++ b/yargs.js
@@ -922,7 +922,7 @@ function Yargs (processArgs, cwd, parentRequire) {
 
   self.terminalWidth = function () {
     argsert([], 0)
-    return process.stdout.columns
+    return process.stdout.columns || null
   }
 
   Object.defineProperty(self, 'argv', {


### PR DESCRIPTION
Run in non-interactive mode:
```javascript
yargs.wrap(yargs.terminalWidth())
```

Raises:
```javascript
YError: Invalid first argument. Expected number or null but received undefined.
    at argumentTypeError (/Users/vitaly/Work/n/node_modules/yargs/lib/argsert.js:70:9)
    at /Users/vitaly/Work/n/node_modules/yargs/lib/argsert.js:41:39
    at Array.forEach (native)
    at module.exports (/Users/vitaly/Work/n/node_modules/yargs/lib/argsert.js:35:21)
    at Object.Yargs.self.wrap (/Users/vitaly/Work/n/node_modules/yargs/yargs.js:692:5)
    at Object.<anonymous> (/Users/vitaly/Work/n/tools/cli.js:275:6)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
```

Because `process.stdout.cols` is `undefined` in non-interactive shell mode.